### PR TITLE
Fix backslashes in documentation examples

### DIFF
--- a/Docs/Amiblitz3.guide
+++ b/Docs/Amiblitz3.guide
@@ -58,7 +58,7 @@
   By the way: The "source" that was available from good old BlitzBasicII was just a
   disassembled machine code, therefore changes are hard to realize.
 
-  In 2006 Sven Dröge took a quick look on the source and started to modernize the GUI and
+  In 2006 Sven Drï¿½ge took a quick look on the source and started to modernize the GUI and
   convert wide parts of the asm-code into AB-code.
   He redesigned the configuration system, the file structure of the IDE-package and
   added some features to PED like a new help system.
@@ -1716,20 +1716,20 @@
   USEPATH          | USEPATH allows you to specify a 'shortcut' path when dealing with NEWTYPE variables.
                    | Consider the following lines of code:
                    | 
-                   | @{fg fill}aliens()\x=160@{fg text}
-                   | @{fg fill}aliens()\y=100@{fg text}
-                   | @{fg fill}aliens()\xs=10@{fg text}
-                   | @{fg fill}aliens()\ys=-10@{fg text}
+                   | @{fg fill}aliens()\\x=160@{fg text}
+                   | @{fg fill}aliens()\\y=100@{fg text}
+                   | @{fg fill}aliens()\\xs=10@{fg text}
+                   | @{fg fill}aliens()\\ys=-10@{fg text}
 
                    | USEPATH can be used to save you some typing, like so:
 
                    | @{fg fill}USEPATH aliens()@{fg text}
-                   | @{fg fill}\x=160@{fg text}
-                   | @{fg fill}\y=100@{fg text}
-                   | @{fg fill}\xs=10@{fg text}
-                   | @{fg fill}\ys=-10@{fg text}
+                   | @{fg fill}\\x=160@{fg text}
+                   | @{fg fill}\\y=100@{fg text}
+                   | @{fg fill}\\xs=10@{fg text}
+                   | @{fg fill}\\ys=-10@{fg text}
 
-                   | Whenever Blitz encounters a variable starting with the backslash character ('\'), it
+                   | Whenever Blitz encounters a variable starting with the backslash character ('\\'), it
                    | simply inserts the current USEPATH text before the backslash.
                    |
                    | 
@@ -1741,14 +1741,14 @@
                    | @{fg fill}DefType.Screen myscreen@{fg text}
                    | 
                    | @{fg fill}USEPATH mywindow@{fg text}
-                   | @{fg fill}NPrint \LeftEdge ; X-position of window@{fg text}
+                   | @{fg fill}NPrint \\LeftEdge ; X-position of window@{fg text}
                    | 
                    | @{fg fill}USEPATH myscreen@{fg text}
-                   | @{fg fill}NPrint \Width    ; Width of screen@{fg text}
-                   | @{fg fill}NPrint \Height   ; Height of screen@{fg text}
+                   | @{fg fill}NPrint \\Width    ; Width of screen@{fg text}
+                   | @{fg fill}NPrint \\Height   ; Height of screen@{fg text}
                    | 
                    | @{fg fill}USELASTPATH@{fg text}
-                   | @{fg fill}NPrint \TopEdge  ; Y position of window@{fg text}
+                   | @{fg fill}NPrint \\TopEdge  ; Y position of window@{fg text}
                    |
                    |
   INCLUDE          | include a source code file
@@ -2590,7 +2590,7 @@ and SharedLibrary examples.
   <HELP> + <SHIFT>              opens guide/autodoc of instruction under cursor
   <HELP> + <CTRL>               opens parameter diagnostic for actual function
   <HELP> on any function        displays syntax help in status line of source window
-  <HELP> on '\'                 opens window 'Definition Browser' and shows newtype information
+  <HELP> on '\\'                 opens window 'Definition Browser' and shows newtype information
   <HELP> on 'EndIf'             shows corresponding IF-Blockheader
 
   <F1>                          opens this guide
@@ -2700,7 +2700,7 @@ and SharedLibrary examples.
     globals   move.l basicvarname(a5),dx
     locals    move.l basicvarname(a4),dx
     newtypes  move.l newtypevar(a5),a0
-              move.l .newtypename\entry(a0),d0
+              move.l .newtypename\\entry(a0),d0
 
     float:    fmove.s basicvarname(a5),dx (FPU on)
 
@@ -2735,19 +2735,19 @@ CEND
 
 
 @{b}Fast string comparision for string upto 4 characters:@{ub}
-if a.l=\@"char1" ....  (a.w=\@"ab" a.b=\@"b")  to compare 4(2/1) char strings fast.
+if a.l=\@"char1" ....  (a.w=\\@"ab" a.b=\\@"b")  to compare 4(2/1) char strings fast.
 
 @{b}Merging Lines:@{ub}
-functioncall {tag1,value1,\@\@     ; use \@\@ to merge lines
+functioncall {tag1,value1,\\@\\@     ; use \\@\\@ to merge lines
               tag2,value2}
 
 @{b}Using "Escape Characters" in strings.@{ub}
 \\n     carriage return
 \\22    A 2 char hexcode that is added as a char in string (22 = ")
-\R09a   print 09 repeatet a. Note that the repeat must always 2 digits
+\\R09a   print 09 repeatet a. Note that the repeat must always 2 digits
 
 @{b}Fast calling of functions:@{ub}
-Function FAST testfunc{var1,var2,\@var3,\@var4}
+Function FAST testfunc{var1,var2,\\@var3,\\@var4}
 
 Functions can be called upto 10-20* faster.
 Dont works if you have strings or newtypes in functions.
@@ -2759,9 +2759,9 @@ its not needed.
 
 @{b}Optional parameter handling for Functions & Statements@{ub}
 Functions and Statements can have variable parameters.
-The "\@" before variables indicates these (\@var3,\@var4) are optional:
+The "\\@" before variables indicates these (\\@var3,\\@var4) are optional:
 
-Function testfunc{var1,var2,\@var3,\@var4}
+Function testfunc{var1,var2,\\@var3,\\@var4}
 End Function
 
 If var3 = -1 then this par is not set do default
@@ -3413,7 +3413,7 @@ End noa7    ;Stack must be at same position as on start so dont use it in
  Recently, Bernd Roesch has updated the compiler and editor and his work has 
  convinced Simon and Mark to allow the release of AmiBlitz as freeware.
  
- Sven Dröge began in 2006 to heavily improve the IDE and reorder the distribution.
+ Sven Drï¿½ge began in 2006 to heavily improve the IDE and reorder the distribution.
 
  Thilo Koehler wrote a powerful compilation of include files that covers a wide area of
  application, as mp3-playback, internet-connectivity, blitting and drawing functions, etc.

--- a/Docs/BlitzProgrammers.guide
+++ b/Docs/BlitzProgrammers.guide
@@ -1748,15 +1748,15 @@ NEWTYPE .Person
     height.q
 End NEWTYPE
 
-a.Person\name="Harry",20,2.1
-NPrint a\height
+a.Person\\name="Harry",20,2.1
+NPrint a\\height
 
 
 Once a NewType is defined, variables are assigned the new type by using a suffix of
 .NewTypename for example a.Person
 
 Individual fields within a NewType variable are accessed and assigned with the
-backslash character "\" for example: a\height=a\height+1.
+backslash character "\\" for example: a\\height=a\\height+1.
 
 When defining a NewType structure, field names without a suffix will be assigned the
 type of the previous field. More than one field can be listed per line of a NewType
@@ -1779,8 +1779,8 @@ compile time error.
 
 @{b}From the first example: @{ub}
 
-a\name="Jimi Hendrix"   ;this is cool
-a\name$="Bob Dylan"     ;this is uncool!
+a\\name="Jimi Hendrix"   ;this is cool
+a\\name$="Bob Dylan"     ;this is uncool!
 
 
 Previously defined NewTypes can be used within subsequent NewType definitions. The
@@ -1801,7 +1801,7 @@ End NewType
 
 DefType .object myship     ;see following paragraph!
 
-myship\position\x=100,0,0
+myship\\position\\x=100,0,0
 
 
 Note how we now need to use two backslashes to access the fields in myship just like
@@ -1838,13 +1838,13 @@ End NEWTYPE
 
 DEFTYPE .record p
 
-p\address[0]="10 St Kevins Arcade"
-p\address[1]="Karangahape Road"
-p\address[2]="Auckland"
-p\address[3]="New Zealand"
+p\\address[0]="10 St Kevins Arcade"
+p\\address[1]="Karangahape Road"
+p\\address[2]="Auckland"
+p\\address[3]="New Zealand"
 
 For i=0 To 3
-    NPrint p\address[i]
+    NPrint p\\address[i]
 Next
 MouseWait
 
@@ -1872,11 +1872,11 @@ path definition when it compiles the program.
 The following code:
 
 
-UsePath shapes(i)\pos
+UsePath shapes(i)\\pos
 For i=0 To 9
-    \x+10
-    \y+20
-    \z-10
+    \\x+10
+    \\y+20
+    \\z-10
 Next
 
 
@@ -1884,9 +1884,9 @@ is expanded internally by the compiler to read:
 
 
 For i=0 To 9
-    shapes(i)\pos\x+10
-    shapes(i)\pos\y+20
-    shapes(i)\pos\z-10
+    shapes(i)\\pos\\x+10
+    shapes(i)\\pos\\y+20
+    shapes(i)\\pos\\z-10
 Next
 
 
@@ -1945,7 +1945,7 @@ all of the aliens x and y entries with random coordinates
 
 
 For k=1 To 100
-    Aliens(k)\x=Rnd(320),Rnd(200)
+    Aliens(k)\\x=Rnd(320),Rnd(200)
 Next
 
 
@@ -2009,7 +2009,7 @@ The following adds one alien to the previously dimmed list:
 
 
 If Additem(Aliens())
-    Aliens()\x=Rnd(320),Rnd(200)
+    Aliens()\\x=Rnd(320),Rnd(200)
 Endif
 
 
@@ -2023,8 +2023,8 @@ fill an entire list with aliens (then kill 'em off slowly!):
 
 
 While Additem(Aliens())
-    Aliens()\x=Rnd(320)
-    Aliens()\y=Rnd(200)
+    Aliens()\\x=Rnd(320)
+    Aliens()\\y=Rnd(200)
 Wend
 
 
@@ -2035,8 +2035,8 @@ we added an alien:
 
 For i=1 To 20
      If Additem(Aliens())
-          Aliens()\x=Rnd(320)
-          Aliens()\v=Rnd(200)
+          Aliens()\\x=Rnd(320)
+          Aliens()\\v=Rnd(200)
      Endif
 Next
 
@@ -2068,8 +2068,8 @@ USEPATH Aliens()
 ResetList Aliens()
 
 While Nextitem(Aliens())
-    If \x>160 Then \x-1 Else \x+1
-    If \y>100 Then \y-1 Else \y+1
+    If \\x>160 Then \\x-1 Else \\x+1
+    If \\y>100 Then \\y-1 Else \\y+1
 Wend
 
 
@@ -2097,7 +2097,7 @@ This may be achieved with Kililtem. This example again works with the Aliens lis
 ResetList Aliens()
 
 While Nextitem(Aliens())
-    If Aliens()\flags=-1    ;if flag=-1
+    If Aliens()\\flags=-1    ;if flag=-1
         Killtem Aliens()    ;remove item from list
     Endif
 Wend
@@ -2152,7 +2152,7 @@ Once we have looped through the list we could print out the Biggest data just as
 it was type Customer when it is actually only a pointer to a variable with type
 customer with:
 
-Print*biggest\name.
+Print*biggest\\name.
 
 @endnode
 
@@ -2391,7 +2391,7 @@ brackets:
 3. Using a .type suffix when referring to items in a NewType will cause a garbage at
 end of line error:
 
-    person\name$="Harry" ;(drop the $)
+    person\\name$="Harry" ;(drop the $)
 
 4. A numeric variable can only be one .type, a MisMatched Type error will occur if
 you attempt to use a different .type suffix further down the program with the same
@@ -2800,8 +2800,8 @@ WindowOutput 0
 Repeat
    ev.l=WaitEvent
    WLocate 0,0
-   NPrint *w\Width
-   NPrint *w\Height
+   NPrint *w\\Width
+   NPrint *w\\Height
 Until ev=$200
 
 
@@ -3313,13 +3313,13 @@ system structures.
 ;variable *mynode   points to a system node
 
 *exec.ExecBase=Peek.l (4)
-*mylist.List=*exec\LibList
-*mynode.Node=*mylist\lh_Head
+*mylist.List=*exec\\LibList
+*mynode.Node=*mylist\\lh_Head
 
-While *mvnode\ln_Succ
-a$=Peek$(*mynode\ln_Name)   ;print node name
+While *mvnode\\ln_Succ
+a$=Peek$(*mynode\\ln_Name)   ;print node name
 NPrint a$
-*mvnode=*mvnode\ln_Succ     ;qo to next node
+*mvnode=*mvnode\\ln_Succ     ;qo to next node
 Wend
 
 MouseWait
@@ -4005,7 +4005,7 @@ If ReadFile (0,"phonebook.data")
     While NOT Eof(0)
         If Additem(people())
             For i=0 To #num-1
-                \info[1]=Edit$(128)
+                \\info[1]=Edit$(128)
             Next
         Endif
     Wend
@@ -4112,12 +4112,12 @@ variable of the same subfield type can be created and that used instead of the
 larger (and slower) path name:
 
 
-UsePath a(i)\alien\pos
+UsePath a(i)\\alien\\pos
 
 replaced by:
 
 UsePath *a
-*a.pos=a(i)\alien
+*a.pos=a(i)\\alien
 
 @endnode
 
@@ -4324,8 +4324,8 @@ End NEWTYPE
 Dim p.pt(n)
 
 For i=0 To n-1
-    p(i)\x=320+Sin(2*1*Pi/n)*319
-    p(i)\y=256+Cos(2*1*Pi/n)*255
+    p(i)\\x=320+Sin(2*1*Pi/n)*319
+    p(i)\\y=256+Cos(2*1*Pi/n)*255
 Next
 
 Screen 0,25        ; hires 1 colour interlace screen
@@ -4333,7 +4333,7 @@ ScreensBitMap 0,0
 
 For i1=0 To n-2
     For i2=i1+1 To n-1
-        Line p(i1)\x,p(i1)\y,p(i2)\x,p(i2)\y,1
+        Line p(i1)\\x,p(i1)\\y,p(i2)\\x,p(i2)\\y,1
     Next
 Next
 
@@ -4343,7 +4343,7 @@ The NewType .pt defined in the program has two items or fields x & y. This means
 that instead of dimming an array of x.w(n) and y.w(n) we can dim one array of
 p.pt(n) which can hold the same information.
 
-The backslash "\" character is used to access the separate fields of the newtype.
+The backslash "\\" character is used to access the separate fields of the newtype.
 The first For..Next loop assigns the points of a circle into the array of points.
 
 The ScreensBitMap command allows us to draw directly onto the screen with the Plot,
@@ -4614,7 +4614,7 @@ If ReadFile (0,"phonebook.data")
     Fileinput 0
     While NOT Eof(0)
         If Additem(people())
-            For i=0 To #num-1:\info[i]=Edit$(128):Next
+            For i=0 To #num-1:\\info[i]=Edit$(128):Next
         Endif
     Wend
 Endif
@@ -4628,7 +4628,7 @@ If NOT Nextitem(people()) Then Additem people()
 refresh:
    ref=0
    For i=0 To #num-1
-        SetString 0,i+1,\info[i]:Redraw 0,i+1
+        SetString 0,i+1,\\info[i]:Redraw 0,i+1
    Next
    ActivateString 0,1:VWait 5
    Repeat
@@ -4639,7 +4639,7 @@ refresh:
                 FileOutput 0
                 ResetList people()
                 While Nextitem(people())
-                    For i=0 To #num-1:NPrint\info[i]:Next
+                    For i=0 To #num-1:NPrint\\info[i]:Next
                 Wend
                 CloseFile 0
             Endif
@@ -4664,7 +4664,7 @@ refresh:
 Until ref=1
 Goto refresh
 Update:
-For i=0 To #num-1:\info[i]=StringText$(0,i+1):Next:Return
+For i=0 To #num-1:\\info[i]=StringText$(0,i+1):Next:Return
 
 @endnode
 
@@ -4715,13 +4715,13 @@ We then point mynode at the next node in the list.
 ;Execlist processor
 
 *exec.ExecBase=Peek.l(4)
-*mylist.List=*exec\LibList
-*mynode.Node=*mylist\lh_Head
+*mylist.List=*exec\\LibList
+*mynode.Node=*mylist\\lh_Head
 
-While *mynode\ln_Succ
-   a$=Peek$(*mynode\1n_Name)
+While *mynode\\ln_Succ
+   a$=Peek$(*mynode\\1n_Name)
    NPrint a$
-   *Amynode=*mynode\ln_Succ
+   *Amynode=*mynode\\ln_Succ
 Wend
 
 MouseWait
@@ -4928,7 +4928,7 @@ End NEWTYPE
 
 Dim List b.ball(n-1)
 While Additem(b())
-    b()\x=Rnd(320-32),Rnd(256-32),Rnd(4)-2,Rnd(4)-2
+    b()\\x=Rnd(320-32),Rnd(256-32),Rnd(4)-2,Rnd(4)-2
 Wend
 
 Gosub getshape
@@ -4948,12 +4948,12 @@ While Joyb(0)=0
     ResetList b()
     USEPATH b()
     While Nextitem(b())
-        \x+\xa:\y+\ya
-        If NOT RectsHit(\x,\y,1,1,0,0,320-32,256-32)
-        \xa=-\xa:\ya=-\ya
-        \x+\xa:\y+\ya
+        \\x+\\xa:\\y+\\ya
+        If NOT RectsHit(\\x,\\y,1,1,0,0,320-32,256-32)
+        \\xa=-\\xa:\\ya=-\\ya
+        \\x+\\xa:\\y+\\ya
         Endif
-        QBlit db,0,\x,\y
+        QBlit db,0,\\x,\\y
     Wend
     MOVE #-1,$dff180
 Wend
@@ -6924,20 +6924,20 @@ shapes etc.
 USEPATH allows you to specify a 'shortcut' path when dealing with NEWTYPE variables.
 Consider the following lines of code:
 
-aliens()\x=160
-aliens()\y=100
-aliens()\xs=10
-aliens()\ys=-10
+aliens()\\x=160
+aliens()\\y=100
+aliens()\\xs=10
+aliens()\\ys=-10
 
 USEPATH can be used to save you some typing, like so:
 
 USEPATH aliens()
-\x=160
-\y=100
-\xs=10
-\ys=-10
+\\x=160
+\\y=100
+\\xs=10
+\\ys=-10
 
-Whenever Blitz encounters a variable starting with the backslash character ('\'), it
+Whenever Blitz encounters a variable starting with the backslash character ('\\'), it
 simply inserts the current USEPATH text before the backslash.
 
 
@@ -11395,11 +11395,11 @@ FindScreen 0
 
 If *f
 
-   NPrint *f\name
-   NPrint *f\ysize
-   NPrint *f\pen1
-   NPrint *f\pen2
-   NPrint *f\drawmode
+   NPrint *f\\name
+   NPrint *f\\ysize
+   NPrint *f\\pen1
+   NPrint *f\\pen2
+   NPrint *f\\drawmode
 
 Else
 
@@ -11578,7 +11578,7 @@ operand.
 So to use FillRexxMsg we must do the following things in our program:
 
 1. Allocate a FillStruct
-2. Set the flags in the FillStruct\Flags.w
+2. Set the flags in the FillStruct\\Flags.w
 3. Fill the FillStruct with either integer values or the addresses of our string
    arguments.
 4. Call FillRexxMsg with the LONG address of our rexxmsg and the LONG address of our
@@ -12722,7 +12722,7 @@ Refer to the Programming in Blitz2 chapter for correct variable nomenclature.
 @{b}Duplicate Label: @{ub}
 
 A label has been defined twice in the same source code. May also occur with macros
-where a label is not preceded by a \@.
+where a label is not preceded by a \\@.
 
 @{b}Label not Found: @{ub}
 
@@ -14699,7 +14699,7 @@ character (the resulting number is in hexadecimal).
 |---|-----------------------------------------------------------------|
 |40 |  @    A   B   C   D   E   F   G   H   I   J   K   L   M   N   O |
 |---|-----------------------------------------------------------------|
-|50 |  P    Q   R   S   T   U   V   W   X   Y   Z   [   \   ]   ^   _ |
+|50 |  P    Q   R   S   T   U   V   W   X   Y   Z   [   \\   ]   ^   _ |
 |---|-----------------------------------------------------------------|
 |60 |  `    a   b   c   d   e   f   g   h   i   j   k   l   m   n   o |
 |---|-----------------------------------------------------------------|


### PR DESCRIPTION
Fix backslashes in documentation examples

Some documentation examples in the guide files use \ in places where the
documentation renderer appears to require \\ to display a literal backslash.

This caused several AmiBlitz field access examples to be shown incorrectly
in the rendered documentation.

This change updates the affected examples so they display correctly.