### PR TITLE
Fix very very old bug in rosette example

### DIFF
--- a/Docs/BlitzProgrammers.guide
+++ b/Docs/BlitzProgrammers.guide
@@ -1,7 +1,7 @@
 @database "programmers guide to Blitz"
 @$VER: programmers_guide_to_Blitz 1.1
 @AUTHOR "Amiblitz team"
-@WORDWRAP 
+@WORDWRAP
 @node Main "programmers guide to Blitz"
                @{b}@{u}GUIDE VERSION OF THE ORIGINAL BLITZ 2.1 MANUAL@{uu}@{ub}
 
@@ -4324,8 +4324,8 @@ End NEWTYPE
 Dim p.pt(n)
 
 For i=0 To n-1
-    p(i)\\x=320+Sin(2*1*Pi/n)*319
-    p(i)\\y=256+Cos(2*1*Pi/n)*255
+    p(i)\\x=320+Sin(2*i*Pi/n)*319
+    p(i)\\y=256+Cos(2*i*Pi/n)*255
 Next
 
 Screen 0,25        ; hires 1 colour interlace screen
@@ -4393,7 +4393,7 @@ Repeat
         Case 1                  ;save fits item 1 which means save
         p$=FileRequest$("FileToSave",path$,name$)
         NPrint "Attempted to Save ",p$
-    
+
         Case 2                  ;hits item 2 which means quit
             End
 
@@ -7920,7 +7920,7 @@ in.
 
 A "Mouse On" must then be executed to enable mouse reading.
 
-If you use the optional parameter in brackets you can attach a sprite to a mouse 
+If you use the optional parameter in brackets you can attach a sprite to a mouse
 connected to port 1.
 
 
@@ -7932,7 +7932,7 @@ define the lower right corner.
 
 MouseArea defaults to an area from 0,0 to 320,200.
 
-If you use the optional parameter in brackets you can decide to set an area for a 
+If you use the optional parameter in brackets you can decide to set an area for a
 mouse connected to port 1.
 
 
@@ -7943,7 +7943,7 @@ function may be used to find the current horizontal location of the mouse. If mo
 reading is enabled, the mouse position will be updated every fiftieth of a second,
 regardless of whether or not a mouse pointer sprite is attached.
 
-If you use the optional parameter in brackets you can decide to read 
+If you use the optional parameter in brackets you can decide to read
 the data of a mouse connected to port 1.
 
 
@@ -7954,7 +7954,7 @@ function may be used to find the current vertical location of the mouse. If mous
 reading is enabled, the mouse position will be updated every fiftieth of a second,
 regardless of whether or not a mouse pointer sprite is attached.
 
-If you use the optional parameter in brackets you can decide to read 
+If you use the optional parameter in brackets you can decide to read
 the data of a mouse connected to port 1.
 
 
@@ -7971,7 +7971,7 @@ MouseXSpeed only has relevance after every vertical blank. Therefore, MouseXSpee
 should only be used after a VWait has been executed, or during a vertical blank
 interupt.
 
-If you use the optional parameter in brackets you can decide to read 
+If you use the optional parameter in brackets you can decide to read
 the data of a mouse connected to port 1.
 
 @{b}MouseYSpeed@{ub}
@@ -7987,7 +7987,7 @@ MouseYSpeed only has relevance after every vertical blank. Therefore, MouseYSpee
 should only be used after a VWait has been executed, or during a vertical blank
 interupt.
 
-If you use the optional parameter in brackets you can decide to read 
+If you use the optional parameter in brackets you can decide to read
 the data of a mouse connected to port 1.
 
 @{b}LoadBlitzFont BlitzFont#,Fontname.font$ @{ub}
@@ -9087,7 +9087,7 @@ true (-1) value, otherwise PColl will return false (0).
 Before using PColl, a DoColl must previously have been executed. Please refer to
 DoColl for more information.
 
-The CLXCON register can only detect collisions between the sprite pairs 0/1, 2/3, 4/5 and 6/7. 
+The CLXCON register can only detect collisions between the sprite pairs 0/1, 2/3, 4/5 and 6/7.
 
 @{b}SColl (Sprite Channel, Sprite Channel) @{ub}
 
@@ -13939,7 +13939,7 @@ The following are the bits assigned to the two DMACON registers:
 15   SET/CLR     determines if bits written with 1 are set or cleared
 14   BBUSY       blister busy flag
 13   BZERO       blister logic zero
-12   X  
+12   X
 11   X
 10   BLTPRI      "blister nasty" signals blister has DMA priority over CPU
 09   DMAEN       enable all DMA below


### PR DESCRIPTION
Fix the rosette example, changing the 1 to the intended i variable. From what I can tell this is a very very old bug. Like decades old.